### PR TITLE
Rename types to avoid future name clash

### DIFF
--- a/src/Bonsai.Ephys/IntanEvalBoard.cs
+++ b/src/Bonsai.Ephys/IntanEvalBoard.cs
@@ -13,18 +13,18 @@ namespace Bonsai.Ephys
     /// </summary>
     [Description("Generates a sequence of buffered samples acquired from an RHA2000-EVAL board.")]
     [Editor("Bonsai.Ephys.Design.IntanEvalBoardEditor, Bonsai.Ephys.Design", typeof(ComponentEditor))]
-    public class IntanEvalBoard : Source<EvalBoardData>
+    public class IntanEvalBoard : Source<IntanEvalBoardData>
     {
         bool settle;
         readonly IntanUsbSource usbSource = new();
-        readonly IObservable<EvalBoardData> source;
+        readonly IObservable<IntanEvalBoardData> source;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IntanEvalBoard"/> class.
         /// </summary>
         public IntanEvalBoard()
         {
-            source = Observable.Create<EvalBoardData>(observer =>
+            source = Observable.Create<IntanEvalBoardData>(observer =>
             {
                 settle = false;
                 int firmwareID1 = 0;
@@ -43,7 +43,7 @@ namespace Bonsai.Ephys
                         {
                             var dataOutput = Mat.FromArray(data.DataFrame);
                             var auxOutput = Mat.FromArray(data.AuxFrame);
-                            observer.OnNext(new EvalBoardData(dataOutput, auxOutput));
+                            observer.OnNext(new IntanEvalBoardData(dataOutput, auxOutput));
                         }
                     }
                 });
@@ -127,10 +127,10 @@ namespace Bonsai.Ephys
         /// RHA2000-EVAL board.
         /// </summary>
         /// <returns>
-        /// A sequence of <see cref="EvalBoardData"/> objects containing buffered amplifier
+        /// A sequence of <see cref="IntanEvalBoardData"/> objects containing buffered amplifier
         /// voltage and auxiliary TTL input data sampled from an RHA2000-EVAL board.
         /// </returns>
-        public override IObservable<EvalBoardData> Generate()
+        public override IObservable<IntanEvalBoardData> Generate()
         {
             return source;
         }

--- a/src/Bonsai.Ephys/IntanEvalBoardData.cs
+++ b/src/Bonsai.Ephys/IntanEvalBoardData.cs
@@ -8,7 +8,7 @@ namespace Bonsai.Ephys
     /// </summary>
     /// <param name="dataFrame">The buffered electrode amplifier voltage data.</param>
     /// <param name="auxFrame">The buffered auxiliary TTL input data.</param>
-    public class EvalBoardData(Mat dataFrame, Mat auxFrame)
+    public class IntanEvalBoardData(Mat dataFrame, Mat auxFrame)
     {
         /// <summary>
         /// Gets the buffered electrode amplifier voltage data.

--- a/src/Bonsai.Ephys/Rhd2000AdcScale.cs
+++ b/src/Bonsai.Ephys/Rhd2000AdcScale.cs
@@ -11,13 +11,13 @@ namespace Bonsai.Ephys
     /// into SI voltage units.
     /// </summary>
     [Description("Rescales ADC values sampled from RHD2000 data blocks into SI voltage units.")]
-    public class AdcScale : Transform<Mat, Mat>
+    public class Rhd2000AdcScale : Transform<Mat, Mat>
     {
         /// <summary>
         /// Gets or sets the type of the ADC from which the input samples were taken.
         /// </summary>
         [Description("The type of the ADC from which the input samples were taken.")]
-        public AdcType AdcType { get; set; }
+        public Rhd2000AdcType AdcType { get; set; }
 
         /// <summary>
         /// Rescales every RHD2000 ADC value in an observable sequence into SI voltage units.
@@ -38,19 +38,19 @@ namespace Bonsai.Ephys
                 var output = new Mat(input.Size, Depth.F32, input.Channels);
                 switch (AdcType)
                 {
-                    case AdcType.Electrode:
+                    case Rhd2000AdcType.Electrode:
                         CV.ConvertScale(input, output, 0.195, -6389.76);
                         break;
-                    case AdcType.AuxiliaryInput:
+                    case Rhd2000AdcType.AuxiliaryInput:
                         CV.ConvertScale(input, output, 0.0000374, 0);
                         break;
-                    case AdcType.SupplyVoltage:
+                    case Rhd2000AdcType.SupplyVoltage:
                         CV.ConvertScale(input, output, 0.0000748, 0);
                         break;
-                    case AdcType.Temperature:
+                    case Rhd2000AdcType.Temperature:
                         CV.ConvertScale(input, output, 1 / 100.0, 0);
                         break;
-                    case AdcType.BoardAdc:
+                    case Rhd2000AdcType.BoardAdc:
                         CV.ConvertScale(input, output, 0.000050354, 0);
                         break;
                     default:

--- a/src/Bonsai.Ephys/Rhd2000AdcType.cs
+++ b/src/Bonsai.Ephys/Rhd2000AdcType.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Specifies the available ADC types in a RHD2000 USB interface board.
     /// </summary>
-    public enum AdcType
+    public enum Rhd2000AdcType
     {
         /// <summary>
         /// Bipolar electrode voltage signals sampled in steps of 0.195 microvolts.

--- a/src/Bonsai.Ephys/Rhd2000TtlState.cs
+++ b/src/Bonsai.Ephys/Rhd2000TtlState.cs
@@ -11,7 +11,7 @@ namespace Bonsai.Ephys
     /// independent channels.
     /// </summary>
     [Description("Demultiplexes TTL digital state into independent channels.")]
-    public class TtlState : Transform<Mat, Mat>
+    public class Rhd2000TtlState : Transform<Mat, Mat>
     {
         /// <summary>
         /// Demultiplexes TTL digital state arrays in an observable sequence into


### PR DESCRIPTION
This PR renames some top-level types to avoid clashing with future package operators, and create an easier deprecation path. The initial package was targeting RHD2000 boards but operator naming conventions were not consistent in making this clear.

This is a breaking change to allow refreshing future package structure.