### PR TITLE
Add option to invert signal polarity

### DIFF
--- a/src/Bonsai.Ephys.Design/Decimator.cs
+++ b/src/Bonsai.Ephys.Design/Decimator.cs
@@ -41,11 +41,11 @@ namespace Bonsai.Ephys.Design
 
         public Depth InputDepth => inputDepth;
 
-        public void Process(Mat input, bool invertPolarity = false)
+        public void Process(Mat input, bool invert = false)
         {
             if (conversionBuffer is not null)
             {
-                CV.ConvertScale(input, conversionBuffer, invertPolarity ? -1 : 1);
+                CV.ConvertScale(input, conversionBuffer, invert ? -1 : 1);
                 input = conversionBuffer;
             }
 

--- a/src/Bonsai.Ephys.Design/Decimator.cs
+++ b/src/Bonsai.Ephys.Design/Decimator.cs
@@ -41,11 +41,11 @@ namespace Bonsai.Ephys.Design
 
         public Depth InputDepth => inputDepth;
 
-        public void Process(Mat input)
+        public void Process(Mat input, bool invertPolarity = false)
         {
             if (conversionBuffer is not null)
             {
-                CV.Convert(input, conversionBuffer);
+                CV.ConvertScale(input, conversionBuffer, invertPolarity ? -1 : 1);
                 input = conversionBuffer;
             }
 

--- a/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
@@ -51,6 +51,7 @@ namespace Bonsai.Ephys.Design
         int colorGrouping = 1;
 
         bool useFixedRange;
+        bool invertSignal = false;
         float rangeAmplitude;
         float rangeOffset;
         string rangeLabel;
@@ -130,8 +131,8 @@ namespace Bonsai.Ephys.Design
                     CV.Range(timeRange, 0, timebase);
                 }
 
-                decimatorMin.Process(data);
-                decimatorMax.Process(data);
+                decimatorMin.Process(data, invertSignal);
+                decimatorMax.Process(data, invertSignal);
             }
         }
 
@@ -196,7 +197,7 @@ namespace Bonsai.Ephys.Design
         unsafe void MenuWidgets()
         {
             var tableFlags = ImGuiTableFlags.NoSavedSettings;
-            if (ImGui.BeginTable("##menu"u8, columns: 6, tableFlags))
+            if (ImGui.BeginTable("##menu"u8, columns: 7, tableFlags))
             {
                 ImGui.TableNextRow();
                 ImGui.PushItemWidth(TextBoxWidth);
@@ -321,6 +322,16 @@ namespace Bonsai.Ephys.Design
                         colorGrouping = Math.Max(1, colorGrouping);
                     ImGui.EndTable();
                 }
+
+                ImGui.TableNextColumn();
+                var color = invertSignal ? ImGui.GetColorU32(ImGuiCol.ButtonActive) : ImGui.GetColorU32(ImGuiCol.Button);
+                ImGui.PushStyleColor(ImGuiCol.Button, color);
+                if (ImGui.Button("Invert\nSignal"u8, buttonSize))
+                {
+                    invertSignal = !invertSignal;
+                }
+
+                ImGui.PopStyleColor();
 
                 ImGui.PopItemWidth();
                 ImGui.EndTable();

--- a/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
@@ -302,14 +302,8 @@ namespace Bonsai.Ephys.Design
                     ImGui.PopStyleColor();
 
                 ImGui.TableNextColumn();
-                var color = invert ? ImGui.GetColorU32(ImGuiCol.ButtonActive) : ImGui.GetColorU32(ImGuiCol.Button);
-                ImGui.PushStyleColor(ImGuiCol.Button, color);
-                if (ImGui.Button("Invert"u8, buttonSize))
-                {
-                    invert = !invert;
-                }
-
-                ImGui.PopStyleColor();
+                ImGui.Text("Signal"u8);
+                ImGui.Checkbox("Invert"u8, ref invert);
 
                 ImGui.TableNextColumn();
                 if (ImGui.BeginTable("##colorThemeT"u8, 1, tableFlags))
@@ -449,6 +443,7 @@ namespace Bonsai.Ephys.Design
             }
 
             imGuiCanvas = new ImGuiControl();
+            imGuiCanvas.Size = new System.Drawing.Size(700, 480);
             imGuiCanvas.Dock = DockStyle.Fill;
             imGuiCanvas.Render += (sender, e) =>
             {

--- a/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
@@ -50,8 +50,8 @@ namespace Bonsai.Ephys.Design
         double timebase = 2.0;
         int colorGrouping = 1;
 
+        bool invert;
         bool useFixedRange;
-        bool invert = false;
         float rangeAmplitude;
         float rangeOffset;
         string rangeLabel;
@@ -111,7 +111,7 @@ namespace Bonsai.Ephys.Design
         }
 
         /// <summary>
-        /// Gets or sets a value specifying if the signal should be inverted.
+        /// Gets or sets a value specifying whether the signal should be inverted.
         /// </summary>
         public bool Invert
         {
@@ -439,11 +439,12 @@ namespace Bonsai.Ephys.Design
                     timebase = visualizerBuilder.Timebase.GetValueOrDefault();
                 if (visualizerBuilder.ColorGrouping.HasValue)
                     colorGrouping = visualizerBuilder.ColorGrouping.GetValueOrDefault();
+                if (visualizerBuilder.Invert.HasValue)
+                    invert = visualizerBuilder.Invert.GetValueOrDefault();
                 useFixedRange = visualizerBuilder.RangeAmplitude.HasValue;
                 rangeAmplitude = (float)visualizerBuilder.RangeAmplitude.GetValueOrDefault();
                 rangeOffset = (float)visualizerBuilder.RangeOffset.GetValueOrDefault();
                 rangeLabel = visualizerBuilder.RangeLabel;
-                invert = visualizerBuilder.Invert;
                 UpdateRangeLimits();
             }
 

--- a/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
@@ -51,7 +51,7 @@ namespace Bonsai.Ephys.Design
         int colorGrouping = 1;
 
         bool useFixedRange;
-        bool invertSignal = false;
+        bool invert = false;
         float rangeAmplitude;
         float rangeOffset;
         string rangeLabel;
@@ -110,6 +110,15 @@ namespace Bonsai.Ephys.Design
             set => rangeAmplitude = (float)value;
         }
 
+        /// <summary>
+        /// Gets or sets a value specifying if the signal should be inverted.
+        /// </summary>
+        public bool Invert
+        {
+            get => invert;
+            set => invert = value;
+        }
+
         /// <inheritdoc/>
         public override void Show(object value)
         {
@@ -131,8 +140,8 @@ namespace Bonsai.Ephys.Design
                     CV.Range(timeRange, 0, timebase);
                 }
 
-                decimatorMin.Process(data, invertSignal);
-                decimatorMax.Process(data, invertSignal);
+                decimatorMin.Process(data, invert);
+                decimatorMax.Process(data, invert);
             }
         }
 
@@ -293,6 +302,16 @@ namespace Bonsai.Ephys.Design
                     ImGui.PopStyleColor();
 
                 ImGui.TableNextColumn();
+                var color = invert ? ImGui.GetColorU32(ImGuiCol.ButtonActive) : ImGui.GetColorU32(ImGuiCol.Button);
+                ImGui.PushStyleColor(ImGuiCol.Button, color);
+                if (ImGui.Button("Invert"u8, buttonSize))
+                {
+                    invert = !invert;
+                }
+
+                ImGui.PopStyleColor();
+
+                ImGui.TableNextColumn();
                 if (ImGui.BeginTable("##colorThemeT"u8, 1, tableFlags))
                 {
                     ImGui.TableNextColumn();
@@ -322,16 +341,6 @@ namespace Bonsai.Ephys.Design
                         colorGrouping = Math.Max(1, colorGrouping);
                     ImGui.EndTable();
                 }
-
-                ImGui.TableNextColumn();
-                var color = invertSignal ? ImGui.GetColorU32(ImGuiCol.ButtonActive) : ImGui.GetColorU32(ImGuiCol.Button);
-                ImGui.PushStyleColor(ImGuiCol.Button, color);
-                if (ImGui.Button("Invert\nSignal"u8, buttonSize))
-                {
-                    invertSignal = !invertSignal;
-                }
-
-                ImGui.PopStyleColor();
 
                 ImGui.PopItemWidth();
                 ImGui.EndTable();
@@ -434,6 +443,7 @@ namespace Bonsai.Ephys.Design
                 rangeAmplitude = (float)visualizerBuilder.RangeAmplitude.GetValueOrDefault();
                 rangeOffset = (float)visualizerBuilder.RangeOffset.GetValueOrDefault();
                 rangeLabel = visualizerBuilder.RangeLabel;
+                invert = visualizerBuilder.Invert;
                 UpdateRangeLimits();
             }
 

--- a/src/Bonsai.Ephys.Design/WaveformVisualizerBuilder.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizerBuilder.cs
@@ -73,6 +73,12 @@ namespace Bonsai.Ephys.Design
         [Description("The label for the waveform amplitude range.")]
         public string RangeLabel { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value specifying if the signal should be inverted.
+        /// </summary>
+        [Description("Specifies if the signal should be inverted.")]
+        public bool Invert { get; set; }
+
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)
         {

--- a/src/Bonsai.Ephys.Design/WaveformVisualizerBuilder.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizerBuilder.cs
@@ -74,10 +74,10 @@ namespace Bonsai.Ephys.Design
         public string RangeLabel { get; set; }
 
         /// <summary>
-        /// Gets or sets a value specifying if the signal should be inverted.
+        /// Gets or sets a value specifying whether the signal should be inverted.
         /// </summary>
-        [Description("Specifies if the signal should be inverted.")]
-        public bool Invert { get; set; }
+        [Description("Specifies whether the signal should be inverted.")]
+        public bool? Invert { get; set; }
 
         /// <inheritdoc/>
         public override Expression Build(IEnumerable<Expression> arguments)


### PR DESCRIPTION
I have been learning more about DearImGui and how it can be applied to this specific waveform visualizer, particularly in how I can help bring more features from the Open Ephys GUI LFP Viewer into this.

This PR adds a new button at the top of the visualizer that allows the user to invert the polarity of the signal by applying `-1` to the signal.

I did not add the option to invert the polarity as a property of the node, but that can be easily added for consistency, since most of the other parameters in the visualizer are exposed as properties.