### PR TITLE
Add feature to expand a single channel's waveform

### DIFF
--- a/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
+++ b/src/Bonsai.Ephys.Design/WaveformVisualizer.cs
@@ -56,6 +56,8 @@ namespace Bonsai.Ephys.Design
         string rangeLabel;
         double vMin;
         double vMax;
+        int selectedChannel = -1;
+        bool expandChannel = false;
 
         /// <summary>
         /// Gets or sets a value specifying the color theme used to style the
@@ -369,6 +371,11 @@ namespace Bonsai.Ephys.Design
 
                 for (int i = 0; i < minShape.Height; i++)
                 {
+                    int rowIndex = i + 1;
+
+                    if (expandChannel && selectedChannel != rowIndex)
+                        continue;
+
                     var labelBuffer = stackalloc byte[32];
                     var channelLabel = new StrBuilder(labelBuffer, 32);
                     channelLabel.Reset();
@@ -376,14 +383,30 @@ namespace Bonsai.Ephys.Design
                     channelLabel.Append(i);
                     channelLabel.End();
 
+                    float height = expandChannel
+                                    ? ImGui.GetContentRegionAvail().Y
+                                    : channelHeight;
+
                     var channelColor = ImPlot.GetColormapColor(i / colorGrouping);
                     ImGui.TableNextRow();
                     ImGui.TableNextColumn();
                     cursorPosY = ImGui.GetCursorPosY();
-                    ImGui.SetCursorPosY(cursorPosY + channelHeight / 2 - 5);
+                    ImGui.SetCursorPosY(cursorPosY + height / 2 - 5);
                     ImGui.Text(channelLabel);
                     ImGui.TableNextColumn();
-                    if (ImPlot.BeginPlot(channelLabel, new(-1, channelHeight), dataPlotFlags))
+
+                    bool isSelected = selectedChannel == rowIndex;
+                    if (ImGui.Selectable($"##ch{i}", isSelected, ImGuiSelectableFlags.AllowDoubleClick, new Vector2(0, height)))
+                    {
+                        selectedChannel = rowIndex;
+                        if (ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
+                        {
+                            expandChannel = !expandChannel;
+                        }
+                    }
+
+                    ImGui.SetCursorPosY(ImGui.GetCursorPosY() - height - 4);
+                    if (ImPlot.BeginPlot(channelLabel, new(-1, height), dataPlotFlags))
                     {
                         ImPlot.PushStyleColor(ImPlotCol.Line, channelColor);
                         ImPlot.SetupAxes(string.Empty, channelLabel, bareAxesFlags, bareAxesFlags);


### PR DESCRIPTION
This PR, similar to #20, aims to bring more features to the waveform visualizer.

This PR adds the ability to select individual channels by clicking on them to provide a visualization that a channel is selected (CH0 is selected below):

<img width="1269" height="528" alt="image" src="https://github.com/user-attachments/assets/72e3aec2-1ebd-42c4-a099-fcf987dac6c3" />

I also added the ability to double-click on each channel to expand it fully, with the same double-click used to go back to the full view:

<img width="1269" height="528" alt="image" src="https://github.com/user-attachments/assets/ea584ffb-081c-4c9a-b06d-02e3bd7d7533" />
